### PR TITLE
Flesh out server apis, and more code separation

### DIFF
--- a/api/https.go
+++ b/api/https.go
@@ -1,0 +1,29 @@
+package api
+
+import (
+	"fmt"
+	"time"
+	"net/http"
+	"net/url"
+	"io/ioutil"
+)
+
+func init() {}
+
+func CheckHost(uuid string) error {
+	var client = &http.Client {Timeout: time.Second * 10}
+	response, err := client.PostForm("http://127.0.0.1:8001/CheckHost",
+		url.Values{"uuid": {uuid}},
+	)
+	if err != nil {
+		return fmt.Errorf("CheckHost call failed: %s", err)
+	}
+
+	defer response.Body.Close()
+
+	ioutil.ReadAll(response.Body)
+	if err != nil {
+		return fmt.Errorf("CheckHost response invalid: %s", err)
+	}
+	return nil
+}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"strings"
-
 	"github.com/AbGuthrie/goquery/commands"
 )
 

--- a/commands/connect.go
+++ b/commands/connect.go
@@ -3,9 +3,7 @@ package commands
 import (
 	"fmt"
 	"strings"
-	"time"
-	"net/http"
-	"io/ioutil"
+	"github.com/AbGuthrie/goquery/api"
 )
 
 func connect(cmdline string) error {
@@ -15,21 +13,11 @@ func connect(cmdline string) error {
 	}
 	fmt.Printf("Connecting to '%s'\n", args[1])
 
-	var client = &http.Client{
-		Timeout: time.Second * 10,
-	}
-	response, err := client.Get("http://127.0.0.1:8001/status")	// TODO parameterize url in config
-	if err != nil {
-		// TODO check status code
-		return fmt.Errorf("Failed to connect %s'", err)
-	}
+	err := api.CheckHost(args[1])
 
-	// Deserialize body bytes
-	body, err := ioutil.ReadAll(response.Body)
 	if err != nil {
-		return fmt.Errorf("Failed to parse response body %s'", err)
+		return errRuntimeError
 	}
-	fmt.Printf("Got response'%s'\n", string(body))
 
 	return nil
 }

--- a/mock_osquery_server.go
+++ b/mock_osquery_server.go
@@ -2,16 +2,67 @@ package main
 
 import (
 	"fmt"
+	"strings"
+	"time"
+	"math/rand"
 	"net/http"
 )
 
+var ENROLL_SECRET string
+var enrolled_hosts map[string]string
+
+func random_string(length int) string {
+	rand.Seed(time.Now().UnixNano())
+	chars := []rune("ABCDEFGHIJKLMNOPQRSTUVWXYZ" +
+		"abcdefghijklmnopqrstuvwxyz" +
+		"0123456789")
+	var b strings.Builder
+	for i := 0; i < length; i++ {
+		b.WriteRune(chars[rand.Intn(len(chars))])
+	}
+	return b.String() // E.g. "ExcbsVQs"
+}
+
+func enroll(w http.ResponseWriter, r *http.Request) {
+	if r.FormValue("enroll_secret") == ENROLL_SECRET {
+		node_key := random_string(32)
+		fmt.Fprintf(w, "{\"node_key\" : \"%s\"}", node_key)
+		enrolled_hosts[node_key] = "unknown_uuid"
+		return
+	}
+	fmt.Fprintf(w, "{\"node_invalid\" : True}")
+}
+
+func config(w http.ResponseWriter, r *http.Request) {}
+func log(w http.ResponseWriter, r *http.Request) {}
+func distributed_read(w http.ResponseWriter, r *http.Request) {}
+func distributed_write(w http.ResponseWriter, r *http.Request) {}
+
+
+// goquery endpoint functions
+func check_host(w http.ResponseWriter, r *http.Request) {
+	fmt.Printf("CheckHost call for: %s", r.FormValue("uuid"));
+}
+
 func main(){
+	ENROLL_SECRET = "somepresharedkey"
 	// TODO enumerate all required endpoints the osquery server must implement
 
 	// GET status
 	http.HandleFunc("/status", func (w http.ResponseWriter, r *http.Request) {
 		fmt.Fprint(w, "%UUID% active")
 	})
+
+
+	// osquery Endpoints
+	http.HandleFunc("/enroll", enroll)
+	http.HandleFunc("/config", config)
+	http.HandleFunc("/log", log)
+	http.HandleFunc("/distribute_read", distributed_read)
+	http.HandleFunc("/distributed_write", distributed_write)
+
+	// goquery Endpoints
+	http.HandleFunc("/CheckHost", check_host)
 
 	http.ListenAndServe(":8001", nil)
 }


### PR DESCRIPTION
This moves the API code into its own module while also helping fill out what the mock server will need to do to support osquery enrollments.