### PR TITLE
Basics for CheckHost

### DIFF
--- a/api/https.go
+++ b/api/https.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"crypto/tls"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -11,19 +12,28 @@ import (
 func init() {}
 
 func CheckHost(uuid string) error {
-	var client = &http.Client{Timeout: time.Second * 10}
-	response, err := client.PostForm("http://127.0.0.1:8001/CheckHost",
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	}
+	var client = &http.Client{Transport: tr, Timeout: time.Second * 10}
+	response, err := client.PostForm("https://127.0.0.1:8001/CheckHost",
 		url.Values{"uuid": {uuid}},
 	)
 	if err != nil {
 		return fmt.Errorf("CheckHost call failed: %s", err)
 	}
-
 	defer response.Body.Close()
 
 	ioutil.ReadAll(response.Body)
 	if err != nil {
 		return fmt.Errorf("CheckHost response invalid: %s", err)
 	}
-	return nil
+	if response.StatusCode == 200 {
+		return nil
+	}
+	if response.StatusCode == 404 {
+		return fmt.Errorf("Unknown Host")
+	}
+	return fmt.Errorf("Server returned unknown error: %d", response.StatusCode)
+
 }

--- a/commands/connect.go
+++ b/commands/connect.go
@@ -16,7 +16,7 @@ func connect(cmdline string) error {
 	err := api.CheckHost(args[1])
 
 	if err != nil {
-		return errRuntimeError
+		return err
 	}
 
 	return nil

--- a/go.mod
+++ b/go.mod
@@ -5,3 +5,5 @@ require (
 	github.com/mattn/go-runewidth v0.0.4 // indirect
 	github.com/pkg/term v0.0.0-20190109203006-aa71e9d9e942 // indirect
 )
+
+go 1.13

--- a/mock_osquery_server.go
+++ b/mock_osquery_server.go
@@ -70,6 +70,13 @@ func distributedWrite(w http.ResponseWriter, r *http.Request) {}
 // goquery endpoint functions
 func checkHost(w http.ResponseWriter, r *http.Request) {
 	fmt.Printf("CheckHost call for: %s", r.FormValue("uuid"))
+	for _, uuid := range enrolledHosts {
+		if uuid == r.FormValue("uuid") {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+	}
+	w.WriteHeader(http.StatusNotFound)
 }
 
 func main() {
@@ -86,7 +93,7 @@ func main() {
 	http.HandleFunc("/enroll", enroll)
 	http.HandleFunc("/config", config)
 	http.HandleFunc("/log", log)
-	http.HandleFunc("/distribute_read", distributedRead)
+	http.HandleFunc("/distributeRead", distributedRead)
 	http.HandleFunc("/distributedWrite", distributedWrite)
 
 	// goquery Endpoints


### PR DESCRIPTION
This is the basic thing that CheckHost should do. It's not efficient but this is the first time we can have osquery AND goquery talking to the host at the same time.