### PR TITLE
Implement More Server APIs

### DIFF
--- a/api/https.go
+++ b/api/https.go
@@ -2,7 +2,9 @@ package api
 
 import (
 	"crypto/tls"
+	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"net/url"
 	"time"
@@ -15,7 +17,7 @@ func CheckHost(uuid string) error {
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 	}
 	var client = &http.Client{Transport: tr, Timeout: time.Second * 10}
-	response, err := client.PostForm("https://127.0.0.1:8001/checkHost",
+	response, err := client.PostForm("https://127.0.0.1:8001/CheckHost",
 		url.Values{"uuid": {uuid}},
 	)
 	if err != nil {
@@ -28,4 +30,38 @@ func CheckHost(uuid string) error {
 		return fmt.Errorf("Unknown Host")
 	}
 	return fmt.Errorf("Server returned unknown error: %d", response.StatusCode)
+}
+
+func ScheduleQuery(uuid string, query string) (string, error) {
+	type QueryScheduleResponse struct {
+		QueryName string `json:"queryName"`
+	}
+
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	}
+	var client = &http.Client{Transport: tr, Timeout: time.Second * 10}
+	response, err := client.PostForm("https://127.0.0.1:8001/ScheduleQuery",
+		url.Values{"uuid": {uuid}, "query": {query}},
+	)
+	if err != nil {
+		return "", fmt.Errorf("ScheduleQuery call failed: %s", err)
+	}
+	if response.StatusCode == 404 {
+		return "", fmt.Errorf("Unknown Host")
+	}
+	if response.StatusCode == 200 {
+		bodyBytes, err := ioutil.ReadAll(response.Body)
+		if err != nil {
+			return "", fmt.Errorf("Could not read response")
+		}
+		qsResponse := QueryScheduleResponse{}
+		err = json.Unmarshal(bodyBytes, &qsResponse);
+		if err != nil {
+			return "", err
+		}
+		return qsResponse.QueryName, nil
+	}
+	return "", fmt.Errorf("Server returned unknown error: %d", response.StatusCode)
+
 }

--- a/commands/command_map.go
+++ b/commands/command_map.go
@@ -19,10 +19,12 @@ func init() {
 	CommandMap = map[string]GoQueryCommand{
 		".connect": connect,
 		".exit":    exit,
+		".query": ScheduleQuery,
 	}
 	SuggestionsMap = []prompt.Suggest{
 		{".connect", "Connect to a host with UUID"},
 		{".exit", "Exit goquery"},
+		{".query", "Schedule a query on a host"},
 	}
 
 	errArgumentError = errors.New("The arguments provided were incorrect for the command")

--- a/commands/query.go
+++ b/commands/query.go
@@ -1,0 +1,28 @@
+package commands
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/AbGuthrie/goquery/api"
+)
+
+func ScheduleQuery(cmdline string) error {
+	args := strings.Split(cmdline, " ") // Separate command and arguments
+	if len(args) == 1 {
+		return fmt.Errorf("A query to run must be provided.\n")
+	}
+	// TODO This needs to support Unicode/Runes
+	commandStripped := cmdline[strings.Index(cmdline, " ") + 1:]
+	fmt.Printf("Running '%s'\n", commandStripped)
+
+	queryName, err := api.ScheduleQuery("", commandStripped)
+
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Query Started With Name: %s\n", queryName)
+
+	return nil
+}

--- a/mock_osquery_server.go
+++ b/mock_osquery_server.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"math/rand"
@@ -10,10 +11,22 @@ import (
 	"time"
 )
 
+type Query struct {
+	Query string
+	Name string
+	Result string
+}
+
 var ENROLL_SECRET string
 var enrolledHosts map[string]string
+var queryMap map[string]map[string]Query
 
-func random_string(length int) string {
+// API Request Struct
+type apiRequest struct {
+	NodeKey string `json:"node_key"`
+}
+
+func randomString(length int) string {
 	rand.Seed(time.Now().UnixNano())
 	chars := []rune("ABCDEFGHIJKLMNOPQRSTUVWXYZ" +
 		"abcdefghijklmnopqrstuvwxyz" +
@@ -22,9 +35,10 @@ func random_string(length int) string {
 	for i := 0; i < length; i++ {
 		b.WriteRune(chars[rand.Intn(len(chars))])
 	}
-	return b.String() // E.g. "ExcbsVQs"
+	return b.String()
 }
 
+// Begin osquery API endpoints
 func enroll(w http.ResponseWriter, r *http.Request) {
 	type enrollPlatformInfo struct {
 		UUID string `json:"uuid"`
@@ -49,50 +63,173 @@ func enroll(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if parsedBody.EnrollSecret == ENROLL_SECRET {
-		node_key := random_string(32)
-		fmt.Fprintf(w, "{\"node_key\" : \"%s\"}", node_key)
-		enrolledHosts[node_key] = parsedBody.PlatformInfo.UUID
-		fmt.Printf("Enrolled a new host with node_key: %s\n", node_key)
+	if parsedBody.EnrollSecret != ENROLL_SECRET {
+		fmt.Printf("Host provided incorrrect secret: %s\n", parsedBody.EnrollSecret)
+		fmt.Fprintf(w, "{\"node_invalid\" : true}")
+		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
 
-	fmt.Printf("Host provided incorrrect secret: %s\n", parsedBody.EnrollSecret)
-	fmt.Fprintf(w, "{\"node_invalid\" : true}")
-	w.WriteHeader(http.StatusBadRequest)
+	nodeKey := randomString(32)
+	fmt.Fprintf(w, "{\"node_key\" : \"%s\"}", nodeKey)
+	enrolledHosts[nodeKey] = parsedBody.PlatformInfo.UUID
+	queryMap[nodeKey] = make(map[string]Query)
+	fmt.Printf("Enrolled a new host with node_key: %s\n", nodeKey)
 }
 
-func config(w http.ResponseWriter, r *http.Request)           {}
-func log(w http.ResponseWriter, r *http.Request)              {}
-func distributedRead(w http.ResponseWriter, r *http.Request)  {}
-func distributedWrite(w http.ResponseWriter, r *http.Request) {}
+func isNodeKeyEnrolled(ar apiRequest) bool {
+	if _, ok := enrolledHosts[ar.NodeKey]; !ok {
+		return false
+	}
+	return true
+}
 
-// goquery endpoint functions
+func httpRequestToAPIRequest(r *http.Request) (apiRequest, error) {
+	parsedRequest := apiRequest{}
+	jsonBytes, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		fmt.Printf("Could not read the body of an API request\n")
+		return apiRequest{}, err
+	}
+	err = json.Unmarshal(jsonBytes, &parsedRequest)
+	if err != nil {
+		return apiRequest{}, err
+	}
+	return parsedRequest, nil
+}
+
+func config(w http.ResponseWriter, r *http.Request) {
+	// This server is designed to test goquery so we don't push a config
+	parsedRequest, err := httpRequestToAPIRequest(r)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	if !isNodeKeyEnrolled(parsedRequest) {
+		fmt.Fprintf(w, "{\"schedule\":{}, \"node_invalid\" : true}")
+		return
+	}
+
+	fmt.Fprintf(w, "{\"schedule\":{}, \"node_invalid\" : false}")
+}
+
+func log(w http.ResponseWriter, r *http.Request)              {
+	// This server is designed to test goquery so we don't do anything with the logs
+}
+
+func distributedRead(w http.ResponseWriter, r *http.Request)  {
+	parsedRequest, err := httpRequestToAPIRequest(r)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	if !isNodeKeyEnrolled(parsedRequest) {
+		fmt.Fprintf(w, "{\"node_invalid\" : true}")
+		return
+	}
+
+	// The check below should never fail. If it does we've really screwed up
+	renderedQueries := ""
+	if _, ok := queryMap[parsedRequest.NodeKey]; !ok {
+		fmt.Fprintf(w, "{\"node_invalid\" : true}")
+		fmt.Printf("This should never occur. A host is enrolled but not configured for distributed\n")
+		return
+	}
+	for name, query := range queryMap[parsedRequest.NodeKey] {
+		if query.Result != "" {
+			continue
+		}
+		renderedQueries += fmt.Sprintf("\"%s\" : \"%s\",\n", name, query.Query)
+	}
+
+	renderedQueries = strings.TrimRight(renderedQueries, ",")
+	fmt.Fprintf(w, "{\"queries\" : {%s}}", renderedQueries)
+}
+
+func distributedWrite(w http.ResponseWriter, r *http.Request) {
+	parsedRequest, err := httpRequestToAPIRequest(r)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	if !isNodeKeyEnrolled(parsedRequest) {
+		fmt.Fprintf(w, "{\"node_invalid\" : true}")
+		return
+	}
+}
+
+// End osquery API endpoints
+
+func checkHostExists(requestedUUID string) (string, error) {
+	for nodeKey, uuid := range enrolledHosts {
+		if uuid == requestedUUID {
+			return nodeKey, nil
+		}
+	}
+	return "", errors.New("No such host")
+}
+
+// Begin goquery APIs
 func checkHost(w http.ResponseWriter, r *http.Request) {
+	uuid := r.FormValue("uuid")
 	fmt.Printf("CheckHost call for: %s", r.FormValue("uuid"))
-	for _, uuid := range enrolledHosts {
-		if uuid == r.FormValue("uuid") {
-			w.WriteHeader(http.StatusOK)
+	if _, ok := checkHostExists(uuid); ok != nil {
+		w.WriteHeader(http.StatusNotFound)
+	}
+}
+
+func scheduleQuery(w http.ResponseWriter, r *http.Request) {
+	uuid := r.FormValue("uuid")
+	fmt.Printf("ScheduleQuery call for: %s", uuid)
+	nodeKey, err := checkHostExists(uuid);
+	if err != nil {
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+	query := Query{}
+	query.Name = randomString(64)
+	query.Query = r.FormValue("query")
+
+	queryMap[nodeKey][query.Name] = query
+	fmt.Fprintf(w, "{\"queryName\" : %s}", query.Name)
+}
+
+func fetchResults(w http.ResponseWriter, r *http.Request) {
+	queryName := r.FormValue("queryName")
+	fmt.Printf("Fetching Results For: %s", queryName)
+	// Yes I know this is really slow. For testing it should be fine
+	// but I will fix this architecture later if needed
+	// The real solution will be to use a better backing store like postgres
+	for _, queries := range queryMap {
+		if query, ok := queries[queryName]; ok {
+			fmt.Fprintf(w, "%s", query.Result)
 			return
 		}
 	}
-	w.WriteHeader(http.StatusNotFound)
 }
+
+// End goquery APIs
 
 func main() {
 	ENROLL_SECRET = "somepresharedsecret"
 	enrolledHosts = make(map[string]string)
+	queryMap = make(map[string]map[string]Query)
 	// TODO enumerate all required endpoints the osquery server must implement
 
 	// osquery Endpoints
 	http.HandleFunc("/enroll", enroll)
 	http.HandleFunc("/config", config)
 	http.HandleFunc("/log", log)
-	http.HandleFunc("/distributeRead", distributedRead)
+	http.HandleFunc("/distributedRead", distributedRead)
 	http.HandleFunc("/distributedWrite", distributedWrite)
 
 	// goquery Endpoints
 	http.HandleFunc("/checkHost", checkHost)
+	http.HandleFunc("/scheduleQuery", scheduleQuery)
+	http.HandleFunc("/fetchResults", fetchResults)
 
 	http.ListenAndServeTLS(":8001", "server.crt", "server.key", nil)
 }


### PR DESCRIPTION
This finishes implementing the APIs osquery needs for goquery compatibility meaning it no longer complains when using the mock server. I also have implemented the ScheduleQuery API but not a way for osquery to put results back (it just noops right now) nor a way for goquery to fetch the results (also a noop).

I also moved some code around to make it more elegant and fixed some variable that were in snake case.