### PR TITLE
Creating state module for goquery shell state (print mode, debug, etc) and implement print lines

### DIFF
--- a/commands/ChangeDirectory.go
+++ b/commands/ChangeDirectory.go
@@ -13,7 +13,7 @@ var verificationTemplate = "select * from file where path = '%s' and type = 'dir
 
 // TODO cd needs to support quoting so you can CD into folders with spaces
 
-func ChangeDirectory(cmdline string) error {
+func changeDirectory(cmdline string) error {
 	host, err := hosts.GetCurrentHost()
 	if err != nil {
 		return fmt.Errorf("No host is currently connected: %s", err)

--- a/commands/ListDirectory.go
+++ b/commands/ListDirectory.go
@@ -12,7 +12,7 @@ import (
 
 // TODO .query should map to Query which is blocking
 
-func ListDirectory(cmdline string) error {
+func listDirectory(cmdline string) error {
 	host, err := hosts.GetCurrentHost()
 	if err != nil {
 		return fmt.Errorf("No host is currently connected: %s", err)
@@ -45,7 +45,7 @@ func ListDirectory(cmdline string) error {
 		return err
 	}
 
-	utils.PrettyPrintQueryResults(results, 0)
+	utils.PrettyPrintQueryResults(results)
 
 	return nil
 }

--- a/commands/command_map.go
+++ b/commands/command_map.go
@@ -20,15 +20,17 @@ func init() {
 	CommandMap = map[string]GoQueryCommand{
 		".connect":    connect,
 		".disconnect": disconnect,
-		".query":      ScheduleQuery,
+		".query":      scheduleQuery,
+		".mode":       changeMode,
 		".exit":       exit,
-		"ls":          ListDirectory,
-		"cd":          ChangeDirectory,
+		"ls":          listDirectory,
+		"cd":          changeDirectory,
 	}
 	SuggestionsMap = []prompt.Suggest{
 		{".connect", "Connect to a host with UUID"},
 		{".disconnect", "Disconnect from a host with UUID"},
 		{".query", "Schedule a query on a host"},
+		{".mode", "Change print mode (json, lines, etc)"},
 		{".exit", "Exit goquery"},
 		{"cd", "Change directories on a remote host"},
 		{"ls", "List the files in the current directory on the remote host"},

--- a/commands/mode.go
+++ b/commands/mode.go
@@ -1,0 +1,32 @@
+package commands
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/AbGuthrie/goquery/config"
+)
+
+var validModes = map[string]config.PrintMode{
+	"json": config.PrintJSON,
+	"line": config.PrintLine,
+}
+
+func changeMode(cmdline string) error {
+	args := strings.Split(cmdline, " ") // Separate command and arguments
+	if len(args) == 1 {
+		return fmt.Errorf("Mode parameter required")
+	}
+	modeArg := args[1]
+
+	// Assert valid mode
+	mode, ok := validModes[modeArg]
+	if !ok {
+		return fmt.Errorf("%s is not a valid print mode", modeArg)
+	}
+
+	config.SetPrintMode(mode)
+	fmt.Printf("Print mode set to '%s'.\n", modeArg)
+
+	return nil
+}

--- a/commands/query.go
+++ b/commands/query.go
@@ -12,7 +12,7 @@ import (
 
 // TODO .query should map to Query which is blocking
 
-func ScheduleQuery(cmdline string) error {
+func scheduleQuery(cmdline string) error {
 	host, err := hosts.GetCurrentHost()
 	if err != nil {
 		return fmt.Errorf("No host is currently connected: %s", err)
@@ -42,7 +42,7 @@ func ScheduleQuery(cmdline string) error {
 		return err
 	}
 
-	utils.PrettyPrintQueryResults(results, 0)
+	utils.PrettyPrintQueryResults(results)
 
 	return nil
 }

--- a/config/state.go
+++ b/config/state.go
@@ -1,0 +1,41 @@
+// Package config is repsonsible for setting and returning the current
+// state of the shell in regards to configuration flags and mode options
+package config
+
+// Config is the struct returned
+type Config struct {
+	CurrentPrintMode PrintMode
+	Debug            bool
+}
+
+// PrintMode is a type to ensure SetPrintMode recieves a valid enum
+type PrintMode int
+
+// PrintMode constants enum
+const (
+	PrintJSON PrintMode = 0
+	PrintLine PrintMode = 1
+)
+
+var config Config
+
+func init() {
+	// TODO this module should be able to load config
+	// defaults from a .config file in ~/.goquery
+	// and should configure host aliases or default hosts
+}
+
+// GetConfig returns a copy of the current state struct
+func GetConfig() Config {
+	return config
+}
+
+// SetDebug assigns .Debug on the current config struct
+func SetDebug(enabled bool) {
+	config.Debug = enabled
+}
+
+// SetPrintMode assigns .CurrentPrintMode on the current config struct
+func SetPrintMode(printMode PrintMode) {
+	config.CurrentPrintMode = printMode
+}

--- a/utils/printer.go
+++ b/utils/printer.go
@@ -1,0 +1,37 @@
+// Package utils holds utility functions like print formatting or conversion functions
+package utils
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+func prettyPrintQueryResultsJSON(results []map[string]string) {
+	fmt.Printf("\n")
+	formatted, err := json.MarshalIndent(results, "", "    ")
+	if err != nil {
+		fmt.Printf("Could not format query results.\n")
+		return
+	}
+	fmt.Printf("%s\n", formatted)
+}
+
+func prettyPrintQueryResultsLines(results []map[string]string) {
+	fmt.Printf("\n")
+	if len(results) == 0 {
+		return
+	}
+	// To center align keys with "=" get longest length key name
+	keyPadding := 0
+	for key := range results[0] {
+		if len(key) > keyPadding {
+			keyPadding = len(key)
+		}
+	}
+	for _, row := range results {
+		for key, val := range row {
+			fmt.Printf("%*s = %s\n", keyPadding, key, val)
+		}
+		fmt.Printf("\n")
+	}
+}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1,24 +1,19 @@
-// Holds utility functions like print formatting or conversion functions
+// Package utils holds utility functions like print formatting or conversion functions
 package utils
 
 import (
-	"encoding/json"
-	"fmt"
+	"github.com/AbGuthrie/goquery/config"
 )
 
-func prettyPrintQueryResultsJSON(results []map[string]string) {
-	formatted, err := json.MarshalIndent(results, "", "    ")
-	if err != nil {
-		fmt.Printf("Could not format query results.\n")
-		return
-	}
-	fmt.Printf("%s\n", formatted)
-}
-
-func PrettyPrintQueryResults(results []map[string]string, format int) {
-	switch format {
-	case 0:
+// PrettyPrintQueryResults prints a given []result map set to standard out
+// taking into consideration the current state.go's print mode
+func PrettyPrintQueryResults(results []map[string]string) {
+	currentConfig := config.GetConfig()
+	switch currentConfig.CurrentPrintMode {
+	case config.PrintJSON:
 		prettyPrintQueryResultsJSON(results)
+	case config.PrintLine:
+		prettyPrintQueryResultsLines(results)
 	default:
 	}
 }


### PR DESCRIPTION
- Created printmode enums and printer.go
- printer.go now has two different print functions (implemented lines)
- Created new command .mode which takes and sets current print mode for the util print switch statement
- Normalized some function names (lowercase since not public to other modules)

Closes #41 and update #11 (print lines)

![image](https://user-images.githubusercontent.com/3303787/66261388-30fa0580-e781-11e9-9634-915111dde52d.png)
