### PR TITLE
Rearchitect the Command Code

### DIFF
--- a/commands/change_directory.go
+++ b/commands/change_directory.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/AbGuthrie/goquery/api"
 	"github.com/AbGuthrie/goquery/hosts"
+
+	prompt "github.com/c-bata/go-prompt"
 )
 
 var verificationTemplate = "select * from file where path = '%s' and type = 'directory'"
@@ -57,4 +59,12 @@ func changeDirectory(cmdline string) error {
 	}
 
 	return nil
+}
+
+func changeDirectoryHelp() string {
+	return "Change directories on a remote host"
+}
+
+func changeDirectorySuggest(cmdline string) []prompt.Suggest {
+	return []prompt.Suggest{}
 }

--- a/commands/clear.go
+++ b/commands/clear.go
@@ -6,6 +6,8 @@ import (
 	"os/exec"
 	"runtime"
 	"strings"
+
+	prompt "github.com/c-bata/go-prompt"
 )
 
 func clear(cmdline string) error {
@@ -25,4 +27,12 @@ func clear(cmdline string) error {
 		print("\033[H\033[2J")
 	}
 	return nil
+}
+
+func clearHelp() string {
+	return "Clear the terminal screen"
+}
+
+func clearSuggest(cmdline string) []prompt.Suggest {
+	return []prompt.Suggest{}
 }

--- a/commands/command_map.go
+++ b/commands/command_map.go
@@ -6,14 +6,16 @@ import (
 	prompt "github.com/c-bata/go-prompt"
 )
 
-// GoQueryCommand the signature type all command functions must conform to
-type GoQueryCommand func(string) error
+// GoQueryCommand defines the functions required to add a new command to goquery
+type GoQueryCommand struct {
+	Execute     func(string) error
+	Help        func() string
+	Suggestions func(string) []prompt.Suggest
+}
 
-// CommandMap is the mapping from command line string to function call
+// CommandMap is the mapping from command line string to GoQueryCommand
+// structure
 var CommandMap map[string]GoQueryCommand
-
-// SuggestionsMap is a prompt integration for autocomplete helpers
-var SuggestionsMap []prompt.Suggest
 
 // Errors
 var errArgumentError error
@@ -21,32 +23,18 @@ var errRuntimeError error
 
 func init() {
 	CommandMap = map[string]GoQueryCommand{
-		".connect":    connect,
-		".disconnect": disconnect,
-		".query":      query,
-		".schedule":   schedule,
-		".resume":     resume,
-		".hosts":      printHosts,
-		".history":    history,
-		".clear":      clear,
-		".mode":       changeMode,
-		".exit":       exit,
-		"ls":          listDirectory,
-		"cd":          changeDirectory,
-	}
-	SuggestionsMap = []prompt.Suggest{
-		{".connect", "Connect to a host with UUID"},
-		{".disconnect", "Disconnect from a host with UUID"},
-		{".query", "Schedule a query on a host and wait for results"},
-		{".schedule", "Schedule a query on host but don't wait for results"},
-		{".resume", "Try to fetch results for query but don't block if unavailable"},
-		{".hosts", "Prints a table of connected hosts"},
-		{".history", "Print the query history for a host from the current session"},
-		{".clear", "Clear the terminal screen"},
-		{".mode", "Change print mode (json, lines, etc)"},
-		{".exit", "Exit goquery"},
-		{"cd", "Change directories on a remote host"},
-		{"ls", "List the files in the current directory on the remote host"},
+		".connect":    GoQueryCommand{connect, connectHelp, connectSuggest},
+		".disconnect": GoQueryCommand{disconnect, disconnectHelp, disconnectSuggest},
+		".query":      GoQueryCommand{query, queryHelp, querySuggest},
+		".schedule":   GoQueryCommand{schedule, scheduleHelp, scheduleSuggest},
+		".resume":     GoQueryCommand{resume, resumeHelp, resumeSuggest},
+		".hosts":      GoQueryCommand{printHosts, printHostsHelp, printHostsSuggest},
+		".history":    GoQueryCommand{history, historyHelp, historySuggest},
+		".clear":      GoQueryCommand{clear, clearHelp, clearSuggest},
+		".mode":       GoQueryCommand{changeMode, changeModeHelp, changeModeSuggest},
+		".exit":       GoQueryCommand{exit, exitHelp, exitSuggest},
+		"ls":          GoQueryCommand{listDirectory, listDirectoryHelp, listDirectorySuggest},
+		"cd":          GoQueryCommand{changeDirectory, changeDirectoryHelp, changeDirectorySuggest},
 	}
 	errArgumentError = errors.New("The arguments provided were incorrect for the command")
 	errRuntimeError = errors.New("There was a problem executing the command")

--- a/commands/connect.go
+++ b/commands/connect.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/AbGuthrie/goquery/api"
 	"github.com/AbGuthrie/goquery/hosts"
+
+	prompt "github.com/c-bata/go-prompt"
 )
 
 func connect(cmdline string) error {
@@ -26,4 +28,16 @@ func connect(cmdline string) error {
 	fmt.Printf("Successfully connected to '%s'.\n", uuid)
 
 	return nil
+}
+
+func connectHelp() string {
+	return "Connect to a host with UUID"
+}
+
+func connectSuggest(cmdline string) []prompt.Suggest {
+	prompts := []prompt.Suggest{}
+	for _, host := range hosts.GetCurrentHosts() {
+		prompts = append(prompts, prompt.Suggest{host.UUID, host.ComputerName})
+	}
+	return prompts
 }

--- a/commands/disconnect.go
+++ b/commands/disconnect.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 
 	"github.com/AbGuthrie/goquery/hosts"
+
+	prompt "github.com/c-bata/go-prompt"
 )
 
 func disconnect(cmdline string) error {
@@ -20,4 +22,16 @@ func disconnect(cmdline string) error {
 	fmt.Printf("Disconnected from '%s'\n", uuid)
 
 	return nil
+}
+
+func disconnectHelp() string {
+	return "Disconnect from a host with UUID"
+}
+
+func disconnectSuggest(cmdline string) []prompt.Suggest {
+	prompts := []prompt.Suggest{}
+	for _, host := range hosts.GetCurrentHosts() {
+		prompts = append(prompts, prompt.Suggest{host.UUID, host.ComputerName})
+	}
+	return prompts
 }

--- a/commands/exit.go
+++ b/commands/exit.go
@@ -3,10 +3,20 @@ package commands
 import (
 	"fmt"
 	"os"
+
+	prompt "github.com/c-bata/go-prompt"
 )
 
 func exit(cmdline string) error {
 	fmt.Printf("Goodbye!\n")
 	os.Exit(0)
 	return errRuntimeError
+}
+
+func exitHelp() string {
+	return "Exit goquery"
+}
+
+func exitSuggest(cmdline string) []prompt.Suggest {
+	return []prompt.Suggest{}
 }

--- a/commands/history.go
+++ b/commands/history.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 
 	"github.com/AbGuthrie/goquery/hosts"
+
+	prompt "github.com/c-bata/go-prompt"
 )
 
 func history(cmdline string) error {
@@ -25,4 +27,12 @@ func history(cmdline string) error {
 	}
 
 	return nil
+}
+
+func historyHelp() string {
+	return "Print the current host's query history from the current session"
+}
+
+func historySuggest(cmdline string) []prompt.Suggest {
+	return []prompt.Suggest{}
 }

--- a/commands/list_directory.go
+++ b/commands/list_directory.go
@@ -7,6 +7,8 @@ import (
 	"github.com/AbGuthrie/goquery/api"
 	"github.com/AbGuthrie/goquery/hosts"
 	"github.com/AbGuthrie/goquery/utils"
+
+	prompt "github.com/c-bata/go-prompt"
 )
 
 // TODO .query should map to Query which is blocking
@@ -30,4 +32,12 @@ func listDirectory(cmdline string) error {
 
 	utils.PrettyPrintQueryResults(results)
 	return nil
+}
+
+func listDirectoryHelp() string {
+	return "List the files in the current directory on the remote host"
+}
+
+func listDirectorySuggest(cmdline string) []prompt.Suggest {
+	return []prompt.Suggest{}
 }

--- a/commands/mode.go
+++ b/commands/mode.go
@@ -2,9 +2,12 @@ package commands
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/AbGuthrie/goquery/config"
+
+	prompt "github.com/c-bata/go-prompt"
 )
 
 var validModes = map[string]config.PrintMode{
@@ -30,4 +33,29 @@ func changeMode(cmdline string) error {
 	fmt.Printf("Print mode set to '%s'.\n", modeArg)
 
 	return nil
+}
+
+func changeModeHelp() string {
+	modeNames := make([]string, 0)
+	for mode, _ := range validModes {
+		modeNames = append(modeNames, mode)
+	}
+	sort.Strings(modeNames)
+	return fmt.Sprintf("Change print mode (%s)", strings.Join(modeNames, ", "))
+}
+
+func changeModeSuggest(cmdline string) []prompt.Suggest {
+	prompts := []prompt.Suggest{}
+
+	modeNames := make([]string, 0)
+	for mode, _ := range validModes {
+		modeNames = append(modeNames, mode)
+	}
+	sort.Strings(modeNames)
+
+	for _, mode := range modeNames {
+		prompts = append(prompts, prompt.Suggest{mode, ""})
+	}
+
+	return prompts
 }

--- a/commands/print_hosts.go
+++ b/commands/print_hosts.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/AbGuthrie/goquery/hosts"
 	"github.com/AbGuthrie/goquery/utils"
+
+	prompt "github.com/c-bata/go-prompt"
 )
 
 func printHosts(cmdline string) error {
@@ -30,4 +32,12 @@ func printHosts(cmdline string) error {
 	utils.PrettyPrintQueryResults(hostRows)
 
 	return nil
+}
+
+func printHostsHelp() string {
+	return "Prints out all connected hosts"
+}
+
+func printHostsSuggest(cmdline string) []prompt.Suggest {
+	return []prompt.Suggest{}
 }

--- a/commands/query.go
+++ b/commands/query.go
@@ -7,9 +7,9 @@ import (
 	"github.com/AbGuthrie/goquery/api"
 	"github.com/AbGuthrie/goquery/hosts"
 	"github.com/AbGuthrie/goquery/utils"
-)
 
-// TODO .query should map to Query which is blocking
+	prompt "github.com/c-bata/go-prompt"
+)
 
 func query(cmdline string) error {
 	host, err := hosts.GetCurrentHost()
@@ -32,4 +32,12 @@ func query(cmdline string) error {
 	utils.PrettyPrintQueryResults(results)
 
 	return nil
+}
+
+func queryHelp() string {
+	return "Schedule a query on a host and wait for results"
+}
+
+func querySuggest(cmdline string) []prompt.Suggest {
+	return []prompt.Suggest{}
 }

--- a/commands/resume.go
+++ b/commands/resume.go
@@ -5,10 +5,11 @@ import (
 	"strings"
 
 	"github.com/AbGuthrie/goquery/api"
+	"github.com/AbGuthrie/goquery/hosts"
 	"github.com/AbGuthrie/goquery/utils"
-)
 
-// TODO .query should map to Query which is blocking
+	prompt "github.com/c-bata/go-prompt"
+)
 
 func resume(cmdline string) error {
 	args := strings.Split(cmdline, " ") // Separate command and arguments
@@ -30,4 +31,21 @@ func resume(cmdline string) error {
 	utils.PrettyPrintQueryResults(results)
 
 	return nil
+}
+
+func resumeHelp() string {
+	return "Try to fetch results for a query but don't block if unavailable"
+}
+
+func resumeSuggest(cmdline string) []prompt.Suggest {
+	host, err := hosts.GetCurrentHost()
+	prompts := []prompt.Suggest{}
+	if err != nil {
+		return prompts
+	}
+
+	for _, query := range host.QueryHistory {
+		prompts = append(prompts, prompt.Suggest{query.Name, query.SQL})
+	}
+	return prompts
 }

--- a/commands/schedule.go
+++ b/commands/schedule.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/AbGuthrie/goquery/api"
 	"github.com/AbGuthrie/goquery/hosts"
-)
 
-// TODO .query should map to Query which is blocking
+	prompt "github.com/c-bata/go-prompt"
+)
 
 func schedule(cmdline string) error {
 	host, err := hosts.GetCurrentHost()
@@ -31,4 +31,12 @@ func schedule(cmdline string) error {
 	fmt.Printf("Scheduled query for host. Resume with name: %s\n", queryName)
 
 	return nil
+}
+
+func scheduleHelp() string {
+	return "Schedule a query on a host but don't wait for results"
+}
+
+func scheduleSuggest(cmdline string) []prompt.Suggest {
+	return []prompt.Suggest{}
 }

--- a/utils/printer.go
+++ b/utils/printer.go
@@ -11,7 +11,6 @@ import (
 type Rows = []map[string]string
 
 func prettyPrintQueryResultsJSON(results Rows) {
-	fmt.Printf("\n")
 	formatted, err := json.MarshalIndent(results, "", "    ")
 	if err != nil {
 		fmt.Printf("Could not format query results.\n")
@@ -21,7 +20,6 @@ func prettyPrintQueryResultsJSON(results Rows) {
 }
 
 func prettyPrintQueryResultsLines(results Rows) {
-	fmt.Printf("\n")
 	if len(results) == 0 {
 		return
 	}


### PR DESCRIPTION
This fixes systemic problem with the architecture of the command code: DRY.

The code before had a suggestions map along with a command map. If a new command was added, you needed to remember to update both or the the command wouldn't work (but goquery would still run) or it wouldn't suggest (even though it was there).

This fixes that by creating a command structure that contains three function pointers: an execute, a help, and a generate command specific suggestions.

This means that all the code and info about a command is packaged together in one file and it's impossible not to write a help function for it guaranteeing that every new command will suggest correctly.

This also makes it trivial to package suggestion generation into the command in question, when the prompt recognizes a full command has been typed, it will call into the command structure for more specific suggestions. Not all commands have suggestions but some do and I've described some of them below:

connect/disconnect: Suggests currently connected hosts
mode: Suggests printing modes
resume: Suggests past queries on that host

Closes: #34 