### PR TITLE
Help Command

### DIFF
--- a/commands/command_map.go
+++ b/commands/command_map.go
@@ -33,6 +33,7 @@ func init() {
 		".clear":      GoQueryCommand{clear, clearHelp, clearSuggest},
 		".mode":       GoQueryCommand{changeMode, changeModeHelp, changeModeSuggest},
 		".exit":       GoQueryCommand{exit, exitHelp, exitSuggest},
+		".help":       GoQueryCommand{help, helpHelp, helpSuggest},
 		"ls":          GoQueryCommand{listDirectory, listDirectoryHelp, listDirectorySuggest},
 		"cd":          GoQueryCommand{changeDirectory, changeDirectoryHelp, changeDirectorySuggest},
 	}

--- a/commands/help.go
+++ b/commands/help.go
@@ -1,0 +1,37 @@
+package commands
+
+import (
+	"sort"
+
+	"github.com/AbGuthrie/goquery/utils"
+
+	prompt "github.com/c-bata/go-prompt"
+)
+
+func help(cmdline string) error {
+	commandNames := make([]string, 0)
+	for k, _ := range CommandMap {
+		commandNames = append(commandNames, k)
+	}
+
+	sort.Strings(commandNames)
+	helpRows := make([]map[string]string, 0)
+
+	for _, commandName := range commandNames {
+		helpRows = append(helpRows, map[string]string{
+			"command":     commandName,
+			"description": CommandMap[commandName].Help(),
+		})
+	}
+
+	utils.PrettyPrintQueryResults(helpRows)
+	return nil
+}
+
+func helpHelp() string {
+	return "Show the help strings for all goquery commands"
+}
+
+func helpSuggest(cmdline string) []prompt.Suggest {
+	return []prompt.Suggest{}
+}

--- a/config/state.go
+++ b/config/state.go
@@ -24,6 +24,7 @@ func init() {
 	// TODO this module should be able to load config
 	// defaults from a .config file in ~/.goquery
 	// and should configure host aliases or default hosts
+	SetPrintMode(PrintPretty)
 }
 
 // GetConfig returns a copy of the current state struct


### PR DESCRIPTION
Implements a simple new help command that lists all the commands available in goquery. It's also useful to test printing methods without having to connect to a host.

This also shows how easy it is to implement new commands with help string in the new system.

Closes #64 