### PR TITLE
Fix Autocomplete Having Blank Lines

### DIFF
--- a/commands/connect.go
+++ b/commands/connect.go
@@ -36,7 +36,7 @@ func connect(cmdline string) error {
 		return err
 	}
 
-	tables := make([]string, len(results))
+	tables := make([]string, 0)
 	for _, row := range results {
 		// Probably unneeded guard against bad osquery/api data
 		if table, ok := row["name"]; ok {

--- a/commands/query.go
+++ b/commands/query.go
@@ -46,7 +46,7 @@ func querySuggest(cmdline string) []prompt.Suggest {
 	}
 
 	// If they've anything other than "from "
-	if parts[len(parts)-2] != "from" || len(parts[len(parts)-1]) == 0 {
+	if parts[len(parts)-2] != "from" {
 		return []prompt.Suggest{}
 	}
 
@@ -57,7 +57,6 @@ func querySuggest(cmdline string) []prompt.Suggest {
 	if err != nil {
 		return prompts
 	}
-
 	for _, table := range host.Tables {
 		prompts = append(prompts, prompt.Suggest{table, ""})
 	}


### PR DESCRIPTION
These two lines should have been in the previous diff but I forgot to `git add` when I amended the commit.

The problem was that I was setting the length of the array (because we know how long it will be) thinking that it would do a C++ style `reserve`. It doesn't, it just adds that many empty elements which is not what I wanted.

So this just removes that.