### PR TITLE
Support Accelerated Query Mode

### DIFF
--- a/docker/config/osquery/osquery.flags
+++ b/docker/config/osquery/osquery.flags
@@ -12,6 +12,6 @@
 --disable_distributed=false
 --distributed_tls_read_endpoint=/distributedRead
 --distributed_tls_write_endpoint=/distributedWrite
---distributed_interval=5
+--distributed_interval=30
 --tls_server_certs=/etc/osquery/server.crt
 --host_identifier=ephemeral

--- a/goserver/mock_osquery_server.go
+++ b/goserver/mock_osquery_server.go
@@ -192,7 +192,11 @@ func distributedRead(w http.ResponseWriter, r *http.Request) {
 	}
 
 	renderedQueries = strings.TrimRight(renderedQueries, ",")
-	fmt.Fprintf(w, "{\"queries\" : {%s}}", renderedQueries)
+	if len(renderedQueries) > 0 {
+		fmt.Fprintf(w, "{\"queries\" : {%s}, \"accelerate\" : 300}", renderedQueries)
+	} else {
+		fmt.Fprintf(w, "{\"queries\" : {%s}}", renderedQueries)
+	}
 }
 
 func distributedWrite(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
osquery has an little known (possibly undocumented) feature where receiving a distribute query can make the host check in much more frequently.

This means you can have your hosts check in ever minute or five until it receives a distributed query at which point it will check in every two seconds.

Up until now our hosts had their distribute interval set at five which is far too low to be used in most infrastructures. Now I've raised it to 30 seconds which is more usual but allowed goserver to accelerate hosts when they receive queries.

The hosts check in every two seconds for five minutes (resetting whenever they get a new query) then go back to their normal interval.

Closes #73 