### PR TITLE
Add Tab Complete To .schedule

### DIFF
--- a/commands/schedule.go
+++ b/commands/schedule.go
@@ -38,5 +38,5 @@ func scheduleHelp() string {
 }
 
 func scheduleSuggest(cmdline string) []prompt.Suggest {
-	return []prompt.Suggest{}
+	return querySuggest(cmdline)
 }


### PR DESCRIPTION
This just patches the `.schedule` command to call into the suggestion generator for `.query`. It makes sense but the linked issue explains why this might not be the best solution.

For now, it's good enough.

Closes #72 