### PR TITLE
Fixed SAML Bugs From Previous Merges

### DIFF
--- a/api/driver.go
+++ b/api/driver.go
@@ -11,8 +11,6 @@ import (
 	"github.com/AbGuthrie/goquery/api/osctrl"
 	"github.com/AbGuthrie/goquery/utils"
 
-	// "github.com/AbGuthrie/goquery/api/private"
-
 	"github.com/AbGuthrie/goquery/hosts"
 )
 

--- a/api/osctrl/https.go
+++ b/api/osctrl/https.go
@@ -69,7 +69,7 @@ func Initialize() (models.GoQueryAPI, error) {
 	}
 	instance.Client = &http.Client{Transport: tr, Timeout: time.Second * 10, Jar: instance.CookieJar}
 
-	return instance, nil
+	return &instance, nil
 }
 
 func credentials() (string, string) {
@@ -85,7 +85,7 @@ func credentials() (string, string) {
 	return strings.TrimSpace(username), password
 }
 
-func (instance osctrlAPI) authenticate() error {
+func (instance *osctrlAPI) authenticate() error {
 	response, err := instance.Client.Get(instance.AdminBase)
 
 	if err != nil {
@@ -133,7 +133,7 @@ func (instance osctrlAPI) authenticate() error {
 	return nil
 }
 
-func (instance osctrlAPI) CheckHost(uuid string) (hosts.Host, error) {
+func (instance *osctrlAPI) CheckHost(uuid string) (hosts.Host, error) {
 	if !instance.Authed {
 		err := instance.authenticate()
 		if err != nil {
@@ -189,7 +189,7 @@ func (instance osctrlAPI) CheckHost(uuid string) (hosts.Host, error) {
 	}, nil
 }
 
-func (instance osctrlAPI) ScheduleQuery(uuid string, query string) (string, error) {
+func (instance *osctrlAPI) ScheduleQuery(uuid string, query string) (string, error) {
 	if !instance.Authed {
 		err := instance.authenticate()
 		if err != nil {
@@ -236,7 +236,7 @@ func (instance osctrlAPI) ScheduleQuery(uuid string, query string) (string, erro
 	return qsResponse.QueryName, nil
 }
 
-func (instance osctrlAPI) FetchResults(queryName string) ([]map[string]string, string, error) {
+func (instance *osctrlAPI) FetchResults(queryName string) ([]map[string]string, string, error) {
 	type ResultsResponse struct {
 		Rows   []map[string]string `json:"results"`
 		Status string              `json:"status"`

--- a/goserver/mock_osquery_server.go
+++ b/goserver/mock_osquery_server.go
@@ -333,6 +333,7 @@ func fetchResults(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
+	w.WriteHeader(http.StatusNotFound)
 }
 
 // End goquery APIs


### PR DESCRIPTION
A lot of code got confused with endpoints, ports, and parameters. We also needed to use pointer receivers instead of copied returns (I really struggle to see the point of non pointer receivers in almost all cases).

Also fixed a bug in mock_server where when a query wasn't found it would still return 200, when it should have returned 404. This was also causing us to misidentify the response as an auth failure prompting to auth again (which was another bug).

Then running the auth flow when already authed would crash goquery (because it couldn't find the saml fields, another bug).

This diff fixes all of that.