### PR TITLE
Aliases Suggestions and Printing Using Mode

### DIFF
--- a/commands/alias.go
+++ b/commands/alias.go
@@ -2,26 +2,41 @@ package commands
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/AbGuthrie/goquery/config"
+	"github.com/AbGuthrie/goquery/utils"
+
 	prompt "github.com/c-bata/go-prompt"
 )
+
+func printAliases() {
+	aliases := config.GetConfig().Aliases
+	aliasNames := make([]string, 0)
+	for name := range aliases {
+		aliasNames = append(aliasNames, name)
+	}
+
+	sort.Strings(aliasNames)
+	aliasRows := make([]map[string]string, 0)
+
+	for _, aliasName := range aliasNames {
+		aliasRows = append(aliasRows, map[string]string{
+			"alias":   aliasName,
+			"command": aliases[aliasName].Command,
+		})
+	}
+
+	utils.PrettyPrintQueryResults(aliasRows)
+}
 
 func alias(cmdline string) error {
 	args := strings.Split(cmdline, " ")
 
 	// If no args provided, print current state of aliases
 	if len(args) == 1 {
-		aliases := config.GetConfig().Aliases
-		if len(aliases) == 0 {
-			fmt.Printf("No aliases set\n")
-			return nil
-		}
-		fmt.Printf("Available aliases:\n\n")
-		for _, alias := range aliases {
-			fmt.Printf("Name:    %s\nCommand: %s\n\n", alias.Name, alias.Command)
-		}
+		printAliases()
 		return nil
 	}
 


### PR DESCRIPTION
Closes #98 

This adds all aliases to tab complete in the prompt with the description being set as the aliased command.

This will definitely need to be updated when we add ATC config commands which are huge but this should work for now. The solution to that I think is two fold:

Add a description to aliases loaded from a file and we can use those, other wise limit to 40 characters of description and add and ellipse.

![IMG_0084](https://user-images.githubusercontent.com/2386877/68625506-2ae8fa00-048e-11ea-9db0-3b7ae4ed0a0b.png)
