### PR TITLE
Instant Switch To Connected Hosts

### DIFF
--- a/commands/connect.go
+++ b/commands/connect.go
@@ -23,8 +23,9 @@ func connect(cmdline string) error {
 
 	// All is good, update hosts state
 	if err := hosts.Register(host); err != nil {
-		return fmt.Errorf("Error connecting to host: %s", err)
+		return err
 	}
+
 	fmt.Printf("Verified Host(%s) Exists.\n", uuid)
 
 	results, err := api.ScheduleQueryAndWait(

--- a/hosts/hosts.go
+++ b/hosts/hosts.go
@@ -51,7 +51,7 @@ func Register(newHost Host) error {
 	for i, host := range connectedHosts {
 		if newHost.UUID == host.UUID {
 			currentHostIndex = i
-			return nil
+			return fmt.Errorf("Active Host Switched")
 		}
 	}
 	connectedHosts = append(connectedHosts, newHost)


### PR DESCRIPTION
Closes #91 

If you’re already connected we don’t send another query all the way down to remote host before allowing you to interact with it again, instead just checking the backend is responding before immediately switching state.

@terracatta