### PR TITLE
Add Alias Description

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -120,7 +120,11 @@ func completer(in prompt.Document) []prompt.Suggest {
 		sort.Strings(suggestions)
 		for _, suggestion := range suggestions {
 			if alias, ok := config.GetConfig().Aliases[suggestion]; ok {
-				prompts = append(prompts, prompt.Suggest{suggestion, alias.Command})
+				description := alias.Description
+				if len(description) == 0 {
+					description = alias.Command
+				}
+				prompts = append(prompts, prompt.Suggest{suggestion, description})
 			} else if command, ok := commands.CommandMap[suggestion]; ok {
 				prompts = append(prompts, prompt.Suggest{suggestion, command.Help()})
 			}

--- a/commands/alias.go
+++ b/commands/alias.go
@@ -23,8 +23,9 @@ func printAliases() {
 
 	for _, aliasName := range aliasNames {
 		aliasRows = append(aliasRows, map[string]string{
-			"alias":   aliasName,
-			"command": aliases[aliasName].Command,
+			"alias":       aliasName,
+			"command":     aliases[aliasName].Command,
+			"description": aliases[aliasName].Description,
 		})
 	}
 

--- a/config.template.json
+++ b/config.template.json
@@ -5,12 +5,15 @@
     "printMode": "pretty",
     "aliases": {
         ".quit": {
+            "description": "Exit goquery",
             "command": ".exit"
         },
         ".all": {
+            "description": "Select everything from a table",
             "command": ".query select * from $#"
         },
         ".si": {
+            "description": "System info",
             "command": ".all system_info"
         }
     }

--- a/config/state.go
+++ b/config/state.go
@@ -14,8 +14,9 @@ import (
 
 // Alias is the struct used to allow abstracted commands
 type Alias struct {
-	Name    string
-	Command string `json:"command"`
+	Name        string
+	Description string `json:"description"`
+	Command     string `json:"command"`
 }
 
 // Config is the struct containing the application state
@@ -86,8 +87,9 @@ func init() {
 			continue
 		}
 		validAliases[aliasName] = Alias{
-			Name:    aliasName,
-			Command: alias.Command,
+			Name:        aliasName,
+			Command:     alias.Command,
+			Description: alias.Description,
 		}
 	}
 	config.Aliases = validAliases


### PR DESCRIPTION
Adds a new field called description that is meant to hold a human readable explanation of what the alias does.

It is chosen as the command description in the typeahead if present, if not, it falls back to filling with the contents of the alias