### PR TITLE
Make commands take a config pointer

### DIFF
--- a/commands/alias.go
+++ b/commands/alias.go
@@ -13,7 +13,7 @@ import (
 	prompt "github.com/c-bata/go-prompt"
 )
 
-func printAliases(config config.Config) {
+func printAliases(config *config.Config) {
 	aliases := config.Aliases
 	aliasNames := make([]string, 0)
 	for name := range aliases {
@@ -34,7 +34,7 @@ func printAliases(config config.Config) {
 	utils.PrettyPrintQueryResults(aliasRows, config.PrintMode)
 }
 
-func alias(api models.GoQueryAPI, config config.Config, cmdline string) error {
+func alias(api models.GoQueryAPI, config *config.Config, cmdline string) error {
 	args := strings.Split(cmdline, " ")
 
 	// If no args provided, print current state of aliases

--- a/commands/change_directory.go
+++ b/commands/change_directory.go
@@ -15,7 +15,7 @@ import (
 
 var verificationTemplate = "select * from file where path = '%s' and type = 'directory'"
 
-func changeDirectory(api models.GoQueryAPI, config config.Config, cmdline string) error {
+func changeDirectory(api models.GoQueryAPI, config *config.Config, cmdline string) error {
 	host, err := hosts.GetCurrentHost()
 	if err != nil {
 		return fmt.Errorf("No host is currently connected: %s", err)

--- a/commands/clear.go
+++ b/commands/clear.go
@@ -12,7 +12,7 @@ import (
 	prompt "github.com/c-bata/go-prompt"
 )
 
-func clear(api models.GoQueryAPI, config config.Config, cmdline string) error {
+func clear(api models.GoQueryAPI, config *config.Config, cmdline string) error {
 	args := strings.Split(cmdline, " ") // Separate command and arguments
 	if len(args) > 1 {
 		return fmt.Errorf("This command takes no parameters")

--- a/commands/command_map.go
+++ b/commands/command_map.go
@@ -10,7 +10,7 @@ import (
 
 // GoQueryCommand defines the functions required to add a new command to goquery
 type GoQueryCommand struct {
-	Execute     func(models.GoQueryAPI, config.Config, string) error
+	Execute     func(models.GoQueryAPI, *config.Config, string) error
 	Help        func() string
 	Suggestions func(string) []prompt.Suggest
 }

--- a/commands/connect.go
+++ b/commands/connect.go
@@ -12,7 +12,7 @@ import (
 	prompt "github.com/c-bata/go-prompt"
 )
 
-func connect(api models.GoQueryAPI, config config.Config, cmdline string) error {
+func connect(api models.GoQueryAPI, config *config.Config, cmdline string) error {
 	args := strings.Split(cmdline, " ") // Separate command and arguments
 	if len(args) == 1 {
 		return fmt.Errorf("Host UUID required")

--- a/commands/disconnect.go
+++ b/commands/disconnect.go
@@ -11,7 +11,7 @@ import (
 	prompt "github.com/c-bata/go-prompt"
 )
 
-func disconnect(api models.GoQueryAPI, config config.Config, cmdline string) error {
+func disconnect(api models.GoQueryAPI, config *config.Config, cmdline string) error {
 	args := strings.Split(cmdline, " ") // Separate command and arguments
 	if len(args) == 1 {
 		return fmt.Errorf("Host UUID required")

--- a/commands/exit.go
+++ b/commands/exit.go
@@ -9,7 +9,7 @@ import (
 	prompt "github.com/c-bata/go-prompt"
 )
 
-func exit(api models.GoQueryAPI, config config.Config, cmdline string) error {
+func exit(api models.GoQueryAPI, config *config.Config, cmdline string) error {
 	fmt.Printf("Goodbye!\n")
 	os.Exit(0)
 	return errRuntimeError

--- a/commands/help.go
+++ b/commands/help.go
@@ -10,7 +10,7 @@ import (
 	prompt "github.com/c-bata/go-prompt"
 )
 
-func help(api models.GoQueryAPI, config config.Config, cmdline string) error {
+func help(api models.GoQueryAPI, config *config.Config, cmdline string) error {
 	commandNames := make([]string, 0)
 	for k, _ := range CommandMap {
 		commandNames = append(commandNames, k)

--- a/commands/history.go
+++ b/commands/history.go
@@ -11,7 +11,7 @@ import (
 	prompt "github.com/c-bata/go-prompt"
 )
 
-func history(api models.GoQueryAPI, config config.Config, cmdline string) error {
+func history(api models.GoQueryAPI, config *config.Config, cmdline string) error {
 	args := strings.Split(cmdline, " ") // Separate command and arguments
 	if len(args) > 1 {
 		return fmt.Errorf("This command takes no parameters")

--- a/commands/list_directory.go
+++ b/commands/list_directory.go
@@ -13,7 +13,7 @@ import (
 	prompt "github.com/c-bata/go-prompt"
 )
 
-func listDirectory(api models.GoQueryAPI, config config.Config, cmdline string) error {
+func listDirectory(api models.GoQueryAPI, config *config.Config, cmdline string) error {
 	host, err := hosts.GetCurrentHost()
 	if err != nil {
 		return fmt.Errorf("No host is currently connected: %s", err)

--- a/commands/mode.go
+++ b/commands/mode.go
@@ -17,7 +17,7 @@ var validModes = map[string]config.PrintModeEnum{
 	"pretty": config.PrintPretty,
 }
 
-func changeMode(api models.GoQueryAPI, config config.Config, cmdline string) error {
+func changeMode(api models.GoQueryAPI, config *config.Config, cmdline string) error {
 	args := strings.Split(cmdline, " ") // Separate command and arguments
 	if len(args) == 1 {
 		return fmt.Errorf("Mode parameter required")

--- a/commands/print_hosts.go
+++ b/commands/print_hosts.go
@@ -12,7 +12,7 @@ import (
 	prompt "github.com/c-bata/go-prompt"
 )
 
-func printHosts(api models.GoQueryAPI, config config.Config, cmdline string) error {
+func printHosts(api models.GoQueryAPI, config *config.Config, cmdline string) error {
 	args := strings.Split(cmdline, " ") // Separate command and arguments
 	if len(args) > 1 {
 		return fmt.Errorf("This command takes no parameters")

--- a/commands/query.go
+++ b/commands/query.go
@@ -12,7 +12,7 @@ import (
 	prompt "github.com/c-bata/go-prompt"
 )
 
-func query(api models.GoQueryAPI, config config.Config, cmdline string) error {
+func query(api models.GoQueryAPI, config *config.Config, cmdline string) error {
 	host, err := hosts.GetCurrentHost()
 	if err != nil {
 		return fmt.Errorf("No host is currently connected: %s", err)

--- a/commands/resume.go
+++ b/commands/resume.go
@@ -12,7 +12,7 @@ import (
 	prompt "github.com/c-bata/go-prompt"
 )
 
-func resume(api models.GoQueryAPI, config config.Config, cmdline string) error {
+func resume(api models.GoQueryAPI, config *config.Config, cmdline string) error {
 	args := strings.Split(cmdline, " ") // Separate command and arguments
 	if len(args) == 1 {
 		return fmt.Errorf("A query name to resume must be provided")

--- a/commands/schedule.go
+++ b/commands/schedule.go
@@ -11,7 +11,7 @@ import (
 	prompt "github.com/c-bata/go-prompt"
 )
 
-func schedule(api models.GoQueryAPI, config config.Config, cmdline string) error {
+func schedule(api models.GoQueryAPI, config *config.Config, cmdline string) error {
 	host, err := hosts.GetCurrentHost()
 	if err != nil {
 		return fmt.Errorf("No host is currently connected: %s", err)

--- a/goquery.go
+++ b/goquery.go
@@ -74,7 +74,7 @@ func executor(input string) {
 
 	// Lookup and run command in command map
 	if command, ok := commands.CommandMap[args[0]]; ok {
-		err := command.Execute(apiInstance, options, input)
+		err := command.Execute(apiInstance, &options, input)
 		if err != nil {
 			fmt.Printf("%s: %s\n", args[0], err.Error())
 		}


### PR DESCRIPTION
This was found because the `mode` command stopped working. It broke because the config structure was passed in by copy instead of reference. I changed the API to be pointers and then tested it and it seems to work now.

I would normally just merge this small fix but because it's an API change would like review from @AbGuthrie 