### PR TITLE
Add ability to pass in external commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,5 +24,9 @@ mock:
 	mkdir -p build/
 	go build -o build/mock_goquery examples/mock.go
 
+mock-external:
+	mkdir -p build/
+	go build -o build/mock_external_goquery examples/mock_external.go
+
 clean:
 	rm -rf build/

--- a/examples/mock_external.go
+++ b/examples/mock_external.go
@@ -11,9 +11,12 @@ import (
 
 	"github.com/AbGuthrie/goquery"
 	"github.com/AbGuthrie/goquery/api/mock"
+	"github.com/AbGuthrie/goquery/commands"
 	"github.com/AbGuthrie/goquery/config"
 	"github.com/AbGuthrie/goquery/hosts"
 	"github.com/AbGuthrie/goquery/models"
+
+	prompt "github.com/c-bata/go-prompt"
 )
 
 func parseConfigOverride(args []string) (string, error) {
@@ -66,6 +69,19 @@ func loadUserConfig() (config.Config, error) {
 	return *decoded, nil
 }
 
+func externalExample(api models.GoQueryAPI, config *config.Config, cmdline string) error {
+	fmt.Println("Greetings from an external command!")
+	return nil
+}
+
+func externalExampleHelp() string {
+	return "Example external command from outside goquery"
+}
+
+func externalExampleSuggest(cmdline string) []prompt.Suggest {
+	return []prompt.Suggest{}
+}
+
 func main() {
 	// 1. Provide something that implements the required models/GoQueryAPI interface,
 	//	  or use a supported built in (see `api/mock` for example implementation)
@@ -97,8 +113,13 @@ func main() {
 			},
 		}
 	}
+	commandMap := map[string]commands.GoQueryCommand{
+		".external": commands.GoQueryCommand{externalExample, externalExampleHelp, externalExampleSuggest},
+		// Possible command that could be used to pull a file from a machine
+		//".get": commands.GoQueryCommand{get, getHelp, getSuggest},
+	}
 	// 3. Call goquery
-	goquery.Run(api, cfg)
+	goquery.RunWithExternalCommands(api, cfg, commandMap)
 }
 
 type myCustomAPI struct {

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,7 @@ module github.com/AbGuthrie/goquery
 
 require (
 	github.com/PuerkitoBio/goquery v1.5.0
+	github.com/aws/aws-sdk-go v1.26.8 // indirect
 	github.com/beevik/etree v1.1.0 // indirect
 	github.com/c-bata/go-prompt v0.2.3
 	github.com/crewjam/saml v0.0.0-20190521120225-344d075952c9

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/PuerkitoBio/goquery v1.5.0 h1:uGvmFXOA73IKluu/F84Xd1tt/z07GYm8X49XKHP
 github.com/PuerkitoBio/goquery v1.5.0/go.mod h1:qD2PgZ9lccMbQlc7eEOjaeRlFQON7xY8kdmcsrnKqMg=
 github.com/andybalholm/cascadia v1.0.0 h1:hOCXnnZ5A+3eVDX8pvgl4kofXv2ELss0bKcqRySc45o=
 github.com/andybalholm/cascadia v1.0.0/go.mod h1:GsXiBklL0woXo1j/WYWtSYYC4ouU9PqHO0sqidkEA4Y=
+github.com/aws/aws-sdk-go v1.26.8 h1:W+MPuCFLSO/itZkZ5GFOui0YC1j3lZ507/m5DFPtzE4=
+github.com/aws/aws-sdk-go v1.26.8/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/beevik/etree v1.1.0 h1:T0xke/WvNtMoCqgzPhkX2r4rjY3GDZFi+FjpRZY2Jbs=
 github.com/beevik/etree v1.1.0/go.mod h1:r8Aw8JqVegEf0w2fDnATrX9VpkMcyFeM0FhwO62wh+A=
 github.com/c-bata/go-prompt v0.2.3 h1:jjCS+QhG/sULBhAaBdjb2PlMRVaKXQgn+4yzaauvs2s=
@@ -10,6 +12,8 @@ github.com/crewjam/saml v0.0.0-20190521120225-344d075952c9 h1:+cz/lCIhz+eg8+jC8c
 github.com/crewjam/saml v0.0.0-20190521120225-344d075952c9/go.mod h1:w5eu+HNtubx+kRpQL6QFT2F3yIFfYVe6+EzOFVU7Hko=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
+github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af h1:pmfjZENx5imkbgOkpRUYLnmbU7UEFbjtDA2hxJ1ichM=
+github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jonboulle/clockwork v0.1.0 h1:VKV+ZcuP6l3yW9doeqz6ziZGgcynBVQO+obU0+0hcPo=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/mattn/go-runewidth v0.0.4 h1:2BvfKmzob6Bmd4YsL0zygOqfdFnK7GR4QL06Do4/p7Y=

--- a/goquery.go
+++ b/goquery.go
@@ -18,6 +18,14 @@ var apiInstance models.GoQueryAPI
 var options config.Config
 
 // Run is the entry point for a file impporting the goquery library to start the prompt REPL
+func RunWithExternalCommands(api models.GoQueryAPI, _config config.Config, _externalCommandMap map[string]commands.GoQueryCommand) {
+	for k, v := range _externalCommandMap {
+		commands.CommandMap[k] = v
+	}
+	Run(api, _config)
+}
+
+// Run is the entry point for a file impporting the goquery library to start the prompt REPL
 func Run(api models.GoQueryAPI, _config config.Config) {
 	// Print errors/warnings with provided aliases, and print state of debug flags
 	_config.Validate()


### PR DESCRIPTION
The goquery library can now handle external commands and will merge them with the command map before starting the command prompt. This allows users to easily add new functions into goquery if those functions might not make sense to upstream without having to fork the library.