### PR TITLE
Allow hosts to be connected by query string other than UUID

### DIFF
--- a/commands/connect.go
+++ b/commands/connect.go
@@ -46,7 +46,7 @@ func connect(api models.GoQueryAPI, config *config.Config, cmdline string) error
 			tables = append(tables, table)
 		}
 	}
-	hosts.SetHostTables(uuid, tables)
+	hosts.SetHostTables(host.UUID, tables)
 
 	return nil
 }


### PR DESCRIPTION
By using the UUID of the returned host to set the tables, we allow the host to be looked up by any string while maintaining a consistent state in the internal datastore.