### PR TITLE
Default to pretty-printing query results

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -14,8 +14,7 @@ func PrettyPrintQueryResults(results models.Rows, printMode config.PrintModeEnum
 		prettyPrintQueryResultsJSON(results)
 	case config.PrintLine:
 		prettyPrintQueryResultsLines(results)
-	case config.PrintPretty:
-		prettyPrintQueryResultsPretty(results)
 	default:
+		prettyPrintQueryResultsPretty(results)
 	}
 }


### PR DESCRIPTION
Prevents the situation in which an empty config causes the query
results not to be printed at all.