### PR TITLE
Fix alias descriptions

### DIFF
--- a/goquery.go
+++ b/goquery.go
@@ -136,7 +136,7 @@ func completer(in prompt.Document) []prompt.Suggest {
 				if len(description) == 0 {
 					description = alias.Command
 				}
-				prompts = append(prompts, prompt.Suggest{Text: suggestion, Description: alias.Command})
+				prompts = append(prompts, prompt.Suggest{Text: suggestion, Description: description})
 			} else if command, ok := commands.CommandMap[suggestion]; ok {
 				prompts = append(prompts, prompt.Suggest{Text: suggestion, Description: command.Help()})
 			}


### PR DESCRIPTION
This got broken in #111 so that descriptions of aliases were never shown. This fixes that.