### PR TITLE
Fix Aliases Without Replacement at End

### DIFF
--- a/utils/alias.go
+++ b/utils/alias.go
@@ -32,5 +32,5 @@ func InterpolateArguments(rawLine string, command string) (string, error) {
 		realizedCommand += arg
 	}
 
-	return realizedCommand, nil
+	return realizedCommand + placeholderParts[len(placeholderParts)-1], nil
 }


### PR DESCRIPTION
The last piece of the query string was not being appended causing aliases to generate invalid queries.

This should fix that I'm testing it now.